### PR TITLE
Avoid repeated type declarations

### DIFF
--- a/lib/youtex/transcript.ex
+++ b/lib/youtex/transcript.ex
@@ -4,17 +4,18 @@ defmodule Youtex.Transcript do
   alias Youtex.HttpClient
   alias Youtex.TranscriptParser
 
+  use Youtex.Types
   use TypedStruct
 
   typedstruct enforce: true do
-    field :video_id, String.t()
+    field :video_id, video_id()
     field :url, String.t()
     field :name, String.t()
-    field :language_code, String.t()
+    field :language_code, language()
     field :generated, boolean()
   end
 
-  @spec build(map, integer) :: t
+  @spec build(map, video_id) :: t
   def build(caption, video_id) do
     %__MODULE__{
       video_id: video_id,

--- a/lib/youtex/transcript.ex
+++ b/lib/youtex/transcript.ex
@@ -8,11 +8,11 @@ defmodule Youtex.Transcript do
   use TypedStruct
 
   typedstruct enforce: true do
-    field :video_id, video_id()
-    field :url, String.t()
-    field :name, String.t()
-    field :language_code, language()
-    field :generated, boolean()
+    field :video_id, video_id
+    field :url, String.t
+    field :name, String.t
+    field :language_code, language
+    field :generated, boolean
   end
 
   @spec build(map, video_id) :: t
@@ -38,7 +38,7 @@ defmodule Youtex.Transcript do
   defp generated(%{"kind" => kind}), do: kind == "asr"
   defp generated(_caption), do: false
 
-  @spec fetch(String.t() | t()) :: [Youtex.t()]
+  @spec fetch(String.t | t) :: [Youtex.t]
   def fetch(transcript) do
     HttpClient.get(transcript.url)
     |> TranscriptParser.parse()

--- a/lib/youtex/transcript_list.ex
+++ b/lib/youtex/transcript_list.ex
@@ -6,7 +6,7 @@ defmodule Youtex.TranscriptList do
   use TypedStruct
 
   typedstruct do
-    field :items, [Transcript.t()], enforce: true
+    field :items, [Transcript.t], enforce: true
   end
 
   @spec build(map, video_id) :: t
@@ -18,7 +18,7 @@ defmodule Youtex.TranscriptList do
 
   def build(_captions, _video_id), do: %__MODULE__{items: []}
 
-  @spec find_for_language(t, language) :: Transcript.t() | nil
+  @spec find_for_language(t, language) :: Transcript.t | nil
   def find_for_language(%__MODULE__{items: transcripts}, language) do
     transcripts
     |> Enum.sort_by(fn

--- a/lib/youtex/transcript_list.ex
+++ b/lib/youtex/transcript_list.ex
@@ -2,15 +2,12 @@ defmodule Youtex.TranscriptList do
   @moduledoc false
 
   alias Youtex.Transcript
-
+  use Youtex.Types
   use TypedStruct
 
   typedstruct do
     field :items, [Transcript.t()], enforce: true
   end
-
-  @type video_id :: String.t()
-  @type language :: String.t()
 
   @spec build(map, video_id) :: t
   def build(%{"captionTracks" => captions}, video_id) do

--- a/lib/youtex/transcript_list_fetcher.ex
+++ b/lib/youtex/transcript_list_fetcher.ex
@@ -1,14 +1,13 @@
 defmodule Youtex.TranscriptListFetcher do
   @moduledoc false
 
+  use Youtex.Types
   alias Youtex.HttpClient
   alias Youtex.TranscriptList
 
   @watch_url "https://www.youtube.com/watch?v="
 
-  @type video_id :: String.t()
-
-  @spec fetch(video_id) :: TranscriptList.t()
+  @spec fetch(video_id()) :: TranscriptList.t()
   def fetch(video_id) do
     fetch_html(video_id)
     |> extract_captions_json()

--- a/lib/youtex/transcript_list_fetcher.ex
+++ b/lib/youtex/transcript_list_fetcher.ex
@@ -7,7 +7,7 @@ defmodule Youtex.TranscriptListFetcher do
 
   @watch_url "https://www.youtube.com/watch?v="
 
-  @spec fetch(video_id()) :: TranscriptList.t()
+  @spec fetch(video_id) :: TranscriptList.t
   def fetch(video_id) do
     fetch_html(video_id)
     |> extract_captions_json()

--- a/lib/youtex/types.ex
+++ b/lib/youtex/types.ex
@@ -1,0 +1,11 @@
+defmodule Youtex.Types do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      @type video_id :: String.t()
+      @type language :: String.t()
+    end
+  end
+
+end

--- a/lib/youtex/types.ex
+++ b/lib/youtex/types.ex
@@ -1,10 +1,15 @@
 defmodule Youtex.Types do
   @moduledoc false
 
+  alias Youtex
+
   defmacro __using__(_opts) do
     quote do
-      @type video_id :: String.t()
-      @type language :: String.t()
+      @type video_id :: String.t
+      @type language :: String.t
+
+      @type success :: {:ok, [Youtex.t]}
+      @type error :: {:error, :not_found}
     end
   end
 

--- a/lib/youtex/youtex.ex
+++ b/lib/youtex/youtex.ex
@@ -9,19 +9,19 @@ defmodule Youtex do
   use TypedStruct
 
   typedstruct enforce: true do
-    field :text, String.t()
-    field :start, float()
-    field :duration, float()
+    field :text, String.t
+    field :start, float
+    field :duration, float
   end
 
   @default_language "en"
 
-  @spec list_transcripts(video_id) :: TranscriptList.t()
+  @spec list_transcripts(video_id) :: TranscriptList.t
   def list_transcripts(video_id) do
     TranscriptListFetcher.fetch(video_id)
   end
 
-  @spec get_transcription(video_id, language) :: {:ok, [t()]} | {:error, :not_found}
+  @spec get_transcription(video_id, language) :: success | error
   def get_transcription(video_id, language \\ @default_language) do
     with transcript_list <- list_transcripts(video_id),
          transcript when transcript != nil <-
@@ -32,7 +32,7 @@ defmodule Youtex do
     end
   end
 
-  @spec get_transcription!(video_id, language) :: [t()]
+  @spec get_transcription!(video_id, language) :: [t]
   def get_transcription!(video_id, language \\ @default_language) do
     case get_transcription(video_id, language) do
       {:ok, transcription} -> transcription

--- a/lib/youtex/youtex.ex
+++ b/lib/youtex/youtex.ex
@@ -5,6 +5,7 @@ defmodule Youtex do
   alias Youtex.TranscriptList
   alias Youtex.TranscriptListFetcher
 
+  use Youtex.Types
   use TypedStruct
 
   typedstruct enforce: true do
@@ -12,9 +13,6 @@ defmodule Youtex do
     field :start, float()
     field :duration, float()
   end
-
-  @type video_id :: String.t()
-  @type language :: String.t()
 
   @default_language "en"
 


### PR DESCRIPTION
Hello @patrykwozinski 

I've wrapped common type declarations in `Youtex.Types`, so we don't need to repeat them. They're injected with the `use` macro.
I've also standardtized the type usage without the `()` at the end. What do you think?

If you think it's good to go, merge it.
If you'd like to change something I can send more commits.
If you don't like de idea, no problem, just close it.

See you next time  :smiley:  